### PR TITLE
Added a joined flickr date

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Then set them as environment variables by running the following commands
 Flickr Joined Date
 ------------------
 
-Date posted cannot be prior to the date you joined Flickr. To handle this, you can set ``FLICKR_JOINED_DATE``. Photos taken before ``FLICKR_JOINED_DATE`` will be given a *date posted* that a seconds after ``FLICKR_JOINED_DATE`` in such a way that those photos gets sorted correctly::
+Date posted cannot be prior to the date you joined Flickr. To handle this, you can set ``FLICKR_JOINED_DATE``. Photos taken before ``FLICKR_JOINED_DATE`` will be given a *date posted* that are seconds after ``FLICKR_JOINED_DATE`` in such a way that those photos gets sorted correctly::
 
   echo "export FLICKR_JOINED_DATE=\"2016-05-10 01:01:01\"" >> $HOME/.bash_profile
   source $HOME/.bash_profile

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,13 @@ Then set them as environment variables by running the following commands
   echo "export FLICKR_SECRET=0123456789abcdef" >> $HOME/.bash_profile
   source $HOME/.bash_profile
 
+Flickr Joined Date
+------------------
+
+Date posted cannot be prior to the date you joined Flickr. To handle this, you can set ``FLICKR_JOINED_DATE``. Photos taken before ``FLICKR_JOINED_DATE`` will be given a *date posted* that a seconds after ``FLICKR_JOINED_DATE`` in such a way that those photos gets sorted correctly::
+
+  echo "export FLICKR_JOINED_DATE=\"2016-05-10 01:01:01\"" >> $HOME/.bash_profile
+  source $HOME/.bash_profile
 
 Install
 -------


### PR DESCRIPTION
Added support for `FLICKR_JOINED_DATE`. Photos taken before `FLICKR_JOINED_DATE` will be given a _date posted_ that are seconds after `FLICKR_JOINED_DATE` in such a way that those photos gets sorted correctly.

This should fix issue #3 and #5.

It also fixes issue #1 by using `time.mktime()` as suggested in #4.
